### PR TITLE
Customize alert styling

### DIFF
--- a/src/components/alert/Alert/index.js
+++ b/src/components/alert/Alert/index.js
@@ -6,9 +6,7 @@ const handleClick = (alert) => () => {
     removeAlert(alert);
 };
 
-const Alert = (props) => {
-    const { alert } = props;
-
+const Alert = ({ alert, style = {}, containerStyle = {}, alertStyle = {}}) => {
     if (alert) {
         const { message, type } = alert;
         const alertTypes = {
@@ -16,26 +14,43 @@ const Alert = (props) => {
             success: '#07CE8F',
             warning: '#FD7400',
         };
-        const style = {
-            container: {
-                backgroundColor: alertTypes[type],
-                color: '#fff',
-                padding: 20,
-                position: 'fixed',
-                textAlign: 'center',
-                top: 0,
-                width: '100%',
-                zIndex: 1031,
+        const x = Object.assign(
+            {},
+            {
+                x: {
+                    cursor: 'pointer',
+                    fontSize: 30,
+                    padding: '0 10px',
+                    position: 'absolute',
+                    right: 10,
+                    top: 10,
+                },
             },
-            x: {
-                cursor: 'pointer',
-                fontSize: 30,
-                padding: '0 10px',
-                position: 'absolute',
-                right: 10,
-                top: 10,
+            alertStyle
+        );
+
+        const container = Object.assign(
+            {},
+            {
+                container: {
+                    backgroundColor: alertTypes[type],
+                    color: '#fff',
+                    padding: 20,
+                    position: 'fixed',
+                    textAlign: 'center',
+                    top: 0,
+                    width: '100%',
+                    zIndex: 1031,
+                },
             },
-        };
+            containerStyle
+        );
+
+        const style = Object.assign(
+            {},
+            {container, x},
+            style
+        );
 
         return (
             <div style={ style.container }>
@@ -57,6 +72,9 @@ Alert.propTypes = {
     alert: PropTypes.shape({
         message: PropTypes.node.isRequired,
         type: PropTypes.oneOf(['danger', 'success', 'warning']),
+        style: PropTypes.object,
+        containerStyle: PropTypes.object,
+        alertStyle: PropTypes.object,
     }),
 };
 

--- a/src/components/alert/Alert/index.js
+++ b/src/components/alert/Alert/index.js
@@ -6,7 +6,7 @@ const handleClick = (alert) => () => {
     removeAlert(alert);
 };
 
-const Alert = ({ alert, style = {}, containerStyle = {}, cancelStyle = {}}) => {
+const Alert = ({ alert, style = {}, containerStyle = {}, cancelStyle = {} }) => {
     if (alert) {
         const { message, type } = alert;
         const alertTypes = {
@@ -46,19 +46,19 @@ const Alert = ({ alert, style = {}, containerStyle = {}, cancelStyle = {}}) => {
             containerStyle
         );
 
-        const style = Object.assign(
+        const componentStyle = Object.assign(
             {},
-            {container, x},
+            { container, x },
             style
         );
 
         return (
-            <div style={ style.container }>
+            <div style={ componentStyle.container }>
                 { message }
 
                 <span
                     onClick={ handleClick(alert) }
-                    style={ style.x }>
+                    style={ componentStyle.x }>
                     &times;
                 </span>
             </div>
@@ -70,12 +70,15 @@ const Alert = ({ alert, style = {}, containerStyle = {}, cancelStyle = {}}) => {
 
 Alert.propTypes = {
     alert: PropTypes.shape({
-        message: PropTypes.node.isRequired,
-        type: PropTypes.oneOf(['danger', 'success', 'warning']),
-        style: PropTypes.object,
-        containerStyle: PropTypes.object,
         cancelStyle: PropTypes.object,
+        containerStyle: PropTypes.object,
+        message: PropTypes.node.isRequired,
+        style: PropTypes.object,
+        type: PropTypes.oneOf(['danger', 'success', 'warning']),
     }),
+    cancelStyle: PropTypes.object,
+    containerStyle: PropTypes.object,
+    style: PropTypes.object,
 };
 
 export default Alert;

--- a/src/components/alert/Alert/index.js
+++ b/src/components/alert/Alert/index.js
@@ -6,7 +6,7 @@ const handleClick = (alert) => () => {
     removeAlert(alert);
 };
 
-const Alert = ({ alert, style = {}, containerStyle = {}, alertStyle = {}}) => {
+const Alert = ({ alert, style = {}, containerStyle = {}, cancelStyle = {}}) => {
     if (alert) {
         const { message, type } = alert;
         const alertTypes = {
@@ -26,7 +26,7 @@ const Alert = ({ alert, style = {}, containerStyle = {}, alertStyle = {}}) => {
                     top: 10,
                 },
             },
-            alertStyle
+            cancelStyle
         );
 
         const container = Object.assign(
@@ -74,7 +74,7 @@ Alert.propTypes = {
         type: PropTypes.oneOf(['danger', 'success', 'warning']),
         style: PropTypes.object,
         containerStyle: PropTypes.object,
-        alertStyle: PropTypes.object,
+        cancelStyle: PropTypes.object,
     }),
 };
 


### PR DESCRIPTION
This PR allows clients of the `Alert` component to override the style choices.

Not sure if this is necessary or useful -- it's not hard to write our own alert components. 